### PR TITLE
added .git in source url

### DIFF
--- a/META.info
+++ b/META.info
@@ -3,5 +3,5 @@
     "version"     : "*",
     "description" : "Implements most of fortune(6)",
     "depends"     : [ "File::Find" ],
-    "source-url"  : "git://github.com/zengargoyle/Text-Fortune"
+    "source-url"  : "git://github.com/zengargoyle/Text-Fortune.git"
 }


### PR DESCRIPTION
We should use full url in meta info. It may also cause this issue https://github.com/perl6/modules.perl6.org/issues/7
